### PR TITLE
AG cloning for test DB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 script:
   - cp ~/build/biocore/labadmin/knimin/config.txt.example ~/build/biocore/labadmin/knimin/config.txt
   - git clone https://github.com/biocore/american-gut-web.git
-  - pwd
+  - ./home/travis/build/biocore/labadmin/american-gut-web/scripts/ag make test
   - nosetests --with-doctest --with-coverage
   - flake8 knimin setup.py scripts
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ install:
   - travis_retry pip install .
 script:
   - cp ~/build/biocore/labadmin/knimin/config.txt.example ~/build/biocore/labadmin/knimin/config.txt
+  - git clone https://github.com/biocore/american-gut-web.git
+  - pwd
   - nosetests --with-doctest --with-coverage
   - flake8 knimin setup.py scripts
 after_success:


### PR DESCRIPTION
This pulls down and runs the `ag make test` from the american-gut-web repo so we have a full test database to use.