### PR TITLE
Use dupes lookup for host_subject_id

### DIFF
--- a/knimin/lib/data_access.py
+++ b/knimin/lib/data_access.py
@@ -687,7 +687,9 @@ class KniminAccess(object):
             md[1][barcode]['HOST_COMMON_NAME'] = md_lookup[site]['COMMON_NAME']
 
             participant_name = dupes_lookup.get(
-                md[1][barcode]['SURVEY_ID'], specific_info['participant_name'])
+                md[1][barcode]['SURVEY_ID'],
+                specific_info['participant_name']).lower()
+
             md[1][barcode]['HOST_SUBJECT_ID'] = sha512(
                 specific_info['ag_login_id'] + participant_name).hexdigest()
 


### PR DESCRIPTION
Requires [american-gut-web #542](https://github.com/biocore/american-gut-web/pull/542)

Uses dupes lookup table to standardize participant names for host_subject_id creation

NOTE: this will fail until #542 is merged. Restart the tests to make it not fail.