### PR TITLE
Add ability to change year and month for postmark date

### DIFF
--- a/knimin/lib/tests/test_geocoder.py
+++ b/knimin/lib/tests/test_geocoder.py
@@ -70,8 +70,8 @@ class TestCallWrapper(TestCase):
 class TestGeocode(TestCase):
     def test_geocode_nonmock(self):
         obs = geocode('9500 Gilman Dr, La Jolla, CA')
-        exp = Location('9500 Gilman Dr, La Jolla, CA', 32.8794081,
-                       -117.2368167, 115.2523956298828, 'San Diego', 'CA',
+        exp = Location('9500 Gilman Dr, La Jolla, CA', 32.8794239,
+                       -117.2369135, 114.7895736694336, 'San Diego', 'CA',
                        '92093', 'United States')
         self.assertEqual(obs, exp)
 

--- a/knimin/templates/barcode_util.html
+++ b/knimin/templates/barcode_util.html
@@ -7,7 +7,9 @@
     $(".chosen-select").chosen();
     $(".date-picker").datepicker({
       changeMonth: true,
-      maxDate: '+0m',
+      changeYear:true,
+      minDate: '-4m',
+      maxDate: '-0',
       onSelect: function(dateText, inst) {
           $(this).focus();
       }


### PR DESCRIPTION
Was brought up that the datepicker for postmark date does not allow you to go back to a different year. This fixes that, so we can log samples across new years changes.