### PR TITLE
Consent checker

### DIFF
--- a/knimin/handlers/ag_consent_check.py
+++ b/knimin/handlers/ag_consent_check.py
@@ -1,0 +1,14 @@
+from knimin.handlers.base import BaseHandler
+from knimin import db
+
+
+class AGConsentCheckHandler(BaseHandler):
+    def get(self):
+        self.render('consent_check.html', consents=[], failures={})
+
+    def post(self):
+        barcodes = [b.strip() for b in
+                    self.get_argument('barcodes').split('\n')]
+        consents, failures = db.check_consent(barcodes)
+        self.render('consent_check.html', consents=sorted(consents),
+                    failures=failures)

--- a/knimin/lib/tests/test_data_access.py
+++ b/knimin/lib/tests/test_data_access.py
@@ -47,6 +47,12 @@ class TestDataAccess(TestCase):
         self.assertTrue('VIOSCREEN' in survey)
         self.assertTrue('BLANK.01' in survey)
 
+    def test_check_consent(self):
+        consent, fail = db.check_consent(['000027561', '000001124', '0000000'])
+        self.assertEqual(consent, ['000027561'])
+        self.assertEqual(fail, {'0000000': 'Not an AG barcode',
+                                '000001124': 'Sample not logged'})
+
 
 if __name__ == "__main__":
     main()

--- a/knimin/templates/consent_check.html
+++ b/knimin/templates/consent_check.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <noscript>
+            <meta HTTP-EQUIV="REFRESH" content="0; url=nojs.html">
+        </noscript>
+        <meta charset="utf-8">
+        <title>Knight lab admin - AG Consent Checker</title>
+
+    </head>
+    <body>
+        {% if consents or failures %}
+        <div>
+          <h2>Consent Results</h2>
+          <p><a href="/consent_check">Back to barcode entry</a></p>
+          <table>
+          <tr><td>Barcode</td><td>Consent Exists</td></tr>
+          {% for barcode in consents %}
+            <tr><td style="padding-right: 10px">{{barcode}}</td><td style="color:green">Yes</td></tr>
+          {% end %}
+          <tr><td style="font-weight:bold">Failures</td><td></td></tr>
+          {% for barcode in sorted(failures) %}
+            <tr><td style="padding-right: 10px">{{barcode}}</td><td style="color:red">{% raw failures[barcode] %}</td></tr>
+          {% end %}
+          </table>
+        </div>
+        {% else %}
+        <div>
+            <h2>Check consent available for barcodes.</h2>
+            <p style="font-weight:bold">Enter one barcode per line.<p>
+            <form action="/consent_check" method="POST" id="barcode_form" name="barcode_form">
+                <p><textarea form="barcode_form" rows=20 cols=12 id="barcodes" name="barcodes"> </textarea></p>
+                <p><input type="submit"></p>
+            </form>
+        </div>
+        {% end %}
+    </body>
+</html>

--- a/knimin/webserver.py
+++ b/knimin/webserver.py
@@ -28,6 +28,7 @@ from knimin.handlers.ag_get_participant_names import (AGNamesHandler,
                                                       AGNamesDLHandler)
 from knimin.handlers.ag_third_party import (AGThirdPartyHandler,
                                             AGNewThirdPartyHandler)
+from knimin.handlers.ag_consent_check import AGConsentCheckHandler
 define("port", default=config.http_port, type=int)
 
 
@@ -66,6 +67,7 @@ class WebApplication(Application):
             (r"/ag_new_barcode/assigned/", AGBarcodeAssignedHandler),
             (r"/ag_third_party/data/", AGThirdPartyHandler),
             (r"/ag_third_party/add/", AGNewThirdPartyHandler),
+            (r"/consent_check", AGConsentCheckHandler),
             (r".*", NoPageHandler)
         ]
         settings = {


### PR DESCRIPTION
This adds a very bare-bones page for checking if one or more barcodes have consent attached. It also gives granular reasons for why a barcode does not have consent, same as the barcode util page.