### PR TITLE
Add subprojects listing to AG scanned barcodes

### DIFF
--- a/knimin/handlers/barcode_util.py
+++ b/knimin/handlers/barcode_util.py
@@ -276,7 +276,9 @@ class BarcodeUtilHandler(BaseHandler, BarcodeUtilHelper):
         email_msg = ag_update_msg = project_msg = None
         exisiting_proj, parent_project = db.getBarcodeProjType(
             barcode)
-        exisiting_proj = set(exisiting_proj.split(','))
+        # This WILL NOT let you remove a sample from being in AG if it is
+        # part of AG to begin with
+        exisiting_proj = set(exisiting_proj.split(', '))
         if exisiting_proj != projects:
             try:
                 add_projects = projects.difference(exisiting_proj)

--- a/knimin/lib/data_access.py
+++ b/knimin/lib/data_access.py
@@ -1977,6 +1977,7 @@ class KniminAccess(object):
         results = [x[0] for x in self._con.execute_fetchall(sql, [barcode])]
         if 'American Gut Project' in results:
             parent_project = 'American Gut'
+            results.remove('American Gut Project')
             projects = ', '.join(results)
         else:
             projects = ', '.join(results)

--- a/knimin/static/css/qiime.css
+++ b/knimin/static/css/qiime.css
@@ -282,7 +282,6 @@ div.verification_color {
 	position: relative;
 	margin-left: 2em;
 	width: 400px;
-	height: 200px;
 	border-radius: 10px;
 	text-align: center;
 }

--- a/knimin/static/css/qiime.css
+++ b/knimin/static/css/qiime.css
@@ -284,6 +284,7 @@ div.verification_color {
 	width: 400px;
 	border-radius: 10px;
 	text-align: center;
+	height: relative;
 }
 
 div.verification_text_wrapper {

--- a/knimin/templates/barcode_util.html
+++ b/knimin/templates/barcode_util.html
@@ -46,10 +46,11 @@
 
 {% if barcode is not None%}
 <div id="{{div_and_msg[0]}}" class="verification_color">
-           <div class="verification_text_wrapper">
+           <div>
               <br />
                 <h2 class="verification_text">
                  Project type: {{parent_project}} <br><br>
+                 Subprojects: {{ barcode_projects }} <br><br>
                  Barcode: {{div_and_msg[2]}}<br><br>
                 {{div_and_msg[1]}}</h2>
             </div>

--- a/knimin/tests/test_barcode_util.py
+++ b/knimin/tests/test_barcode_util.py
@@ -162,12 +162,13 @@ class TestBarcodeUtil(TestHandlerBase):
         self.assertIn('Project successfully changed', response.body)
         barcode_projects, parent_project = db.getBarcodeProjType(self.ag_good)
         self.assertEqual(barcode_projects, 'UNKNOWN')
+        self.assertEqual(parent_project, 'American Gut')
 
         # reset back
-        db.setBarcodeProjects(self.ag_good, ['American Gut Project'],
-                              ['UNKNOWN'])
+        db.setBarcodeProjects(self.ag_good, rem_projects=['UNKNOWN'])
         barcode_projects, parent_project = db.getBarcodeProjType(self.ag_good)
-        self.assertEqual(barcode_projects, 'American Gut Project')
+        self.assertEqual(barcode_projects, '')
+        self.assertEqual(parent_project, 'American Gut')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Makes subprojects prominent on the barcode scan page.