### PR TITLE
Remove errant handout kits

### DIFF
--- a/knimin/handlers/ag_view_handout.py
+++ b/knimin/handlers/ag_view_handout.py
@@ -1,0 +1,14 @@
+from tornado.web import authenticated
+from knimin.handlers.base import BaseHandler
+from knimin.handlers.access_decorators import set_access
+
+from knimin import db
+
+
+@set_access(['Create AG kits'])
+class AGViewHandoutHandler(BaseHandler):
+    @authenticated
+    def get(self):
+        kits = db.get_handout_kits()
+
+        self.render('ag_view_handout.html', kits=kits)

--- a/knimin/handlers/ag_view_handout.py
+++ b/knimin/handlers/ag_view_handout.py
@@ -1,3 +1,5 @@
+from json import loads
+
 from tornado.web import authenticated
 from knimin.handlers.base import BaseHandler
 from knimin.handlers.access_decorators import set_access
@@ -12,3 +14,14 @@ class AGViewHandoutHandler(BaseHandler):
         kits = db.get_handout_kits()
 
         self.render('ag_view_handout.html', kits=kits)
+
+    @authenticated
+    def post(self):
+        kits = loads(self.get_argument('kits'))
+        print kits
+        try:
+            db.delete_ag_kits(self.current_user, kits)
+        except Exception as e:
+            self.write('ERROR: %s' % str(e))
+            return
+        self.write('Success')

--- a/knimin/handlers/ag_view_handout.py
+++ b/knimin/handlers/ag_view_handout.py
@@ -18,7 +18,6 @@ class AGViewHandoutHandler(BaseHandler):
     @authenticated
     def post(self):
         kits = loads(self.get_argument('kits'))
-        print kits
         try:
             db.delete_ag_kits(self.current_user, kits)
         except Exception as e:

--- a/knimin/handlers/ag_view_handout.py
+++ b/knimin/handlers/ag_view_handout.py
@@ -7,7 +7,7 @@ from knimin.handlers.access_decorators import set_access
 from knimin import db
 
 
-@set_access(['Create AG kits'])
+@set_access(['Admin'])
 class AGViewHandoutHandler(BaseHandler):
     @authenticated
     def get(self):

--- a/knimin/lib/data_access.py
+++ b/knimin/lib/data_access.py
@@ -1342,6 +1342,27 @@ class KniminAccess(object):
 
         return kits
 
+    def delete_ag_kits(self, email, kit_ids):
+        """Remove handout kits from the server
+
+        Parameters
+        ----------
+        email : str
+            Email of the user requesting the delete. Not strictly needed, but
+            asked for as a safety measure
+        kit_ids : list of str
+            Kits to delete
+        """
+        if not self.has_access(email, ['Admin', 'Create AG kits']):
+            raise ValueError('User %s does not have delete permissions!' %
+                             email)
+
+        bc_sql = "DELETE FROM ag.ag_handout_barcodes WHERE kit_id in %s"
+        kit_sql = "DELETE FROM ag.ag_handout_kits WHERE kit_id in %s"
+        kits = tuple(kit_ids)
+        self._con.execute(bc_sql, [kits])
+        self._con.execute(kit_sql, [kits])
+
     def get_used_kit_ids(self):
         """Grab in use kit IDs, return set of them
         """

--- a/knimin/lib/data_access.py
+++ b/knimin/lib/data_access.py
@@ -2008,6 +2008,32 @@ class KniminAccess(object):
         liketerm = '%%' + term + '%%'
         return self._con.execute_fetchdict(sql, [liketerm, liketerm])
 
+    def get_handout_kits(self, kit_ids=None):
+        """Gets information on handout kits
+
+        Parameters
+        ----------
+        kit_ids : list of str, optional
+            List of kits to get info for. Default all handout kits
+
+        Returns
+        -------
+        list of dicts of objects
+            Each kit as a dict with all available info. Barcodes are a list
+            under the barcode key.
+        """
+        sql = """SELECT kit_id, verification_code, swabs_per_kit, created_on,
+                 array_agg(barcode) as barcodes
+                 FROM ag.ag_handout_kits
+                 JOIN ag.ag_handout_barcodes USING (kit_id)"""
+        sql_args = None
+        if kit_ids is not None:
+            sql += 'WHERE kit_ids IN %s'
+            sql_args = [tuple(kit_ids)]
+        sql += ' GROUP BY kit_id, verification_code, swabs_per_kit, created_on'
+
+        return self._con.execute_fetchdict(sql, sql_args)
+
     def get_login_by_email(self, email):
         sql = """SELECT name, address, city, state, zip, country, ag_login_id
                  FROM ag_login WHERE email = %s"""

--- a/knimin/lib/tests/test_data_access.py
+++ b/knimin/lib/tests/test_data_access.py
@@ -60,6 +60,11 @@ class TestDataAccess(TestCase):
         exp = ['000014660', datetime.date(2015, 3, 25), 'REMOVED']
         self.assertEqual(obs[0], exp)
 
+    def test_get_handout_kits(self):
+        obs = db.get_handout_kits()
+        self.assertEqual(obs[0].keys(), ['kit_id', 'barcodes', 'created_on',
+                                         'swabs_per_kit', 'verification_code'])
+
 
 if __name__ == "__main__":
     main()

--- a/knimin/templates/ag_view_handout.html
+++ b/knimin/templates/ag_view_handout.html
@@ -1,0 +1,48 @@
+{% extends auth_sitebase.html %}
+{% block head %}
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/t/dt/jszip-2.5.0,dt-1.10.11,b-1.1.2,b-html5-1.1.2,se-1.1.2/datatables.min.css"/>
+<script type="text/javascript" src="https://cdn.datatables.net/t/dt/jszip-2.5.0,dt-1.10.11,b-1.1.2,b-html5-1.1.2,se-1.1.2/datatables.min.js"></script>
+<script type="text/javascript">
+$(document).ready(function () {
+  $("#handout-table").DataTable({
+    dom: 'Bfrtip',
+    pageLength: 50,
+    "order": [[ 4, "desc" ]],
+    "columns": [
+      null,
+      null,
+      null,
+      { "width": "50%" },
+      null
+    ],
+    select: true,
+    buttons: [
+      'excel',
+      {
+        extend: 'selected',
+        text: 'Delete Kits',
+        action: function (e, dt, button, config) { console.log('DELETING!'); }
+      },
+      {
+        extend: 'selected',
+        text: 'Download kit printouts',
+        action: function (e, dt, button, config) { console.log('REPRINT!'); }
+      }
+    ]
+  });
+});
+</script>
+{% end %}
+{% block content %}
+<h3>Handout Kit Review</h3>
+<table id="handout-table">
+  <thead>
+    <tr><td>Kit ID</td><td>Verification Code</td><td>Swabs per kit</td><td>Barcodes</td><td>Created On</td></tr>
+  </thead>
+  <tbody>
+  {% for kit in kits %}
+  <tr><td>{{ kit['kit_id'] }}</td><td>{{ kit['verification_code'] }}</td><td>{{ kit['swabs_per_kit'] }}</td><td>{% raw ', '.join(kit['barcodes']) %}</td><td>{{ kit['created_on'].strftime('%Y-%m-%d %I:%M %p') }}</td></tr>
+  {% end %}
+  </tbody>
+</table>
+{% end %}

--- a/knimin/templates/ag_view_handout.html
+++ b/knimin/templates/ag_view_handout.html
@@ -21,12 +21,20 @@ $(document).ready(function () {
       {
         extend: 'selected',
         text: 'Delete Kits',
-        action: function (e, dt, button, config) { console.log('DELETING!'); }
-      },
-      {
-        extend: 'selected',
-        text: 'Download kit printouts',
-        action: function (e, dt, button, config) { console.log('REPRINT!'); }
+        action: function (e, dt, button, config) {
+          var kits = [];
+          dt.rows({ selected: true }).every(function() {
+            kits.push(this.data()[0]);
+          });
+          $.post('/ag_view_handout/', {kits: JSON.stringify(kits)})
+            .done(function(data) {
+              if (data == 'Success') {
+                history.go(0);
+              } else {
+                alert(data);
+              }
+            });
+        }
       }
     ]
   });

--- a/knimin/templates/ag_view_handout.html
+++ b/knimin/templates/ag_view_handout.html
@@ -26,14 +26,17 @@ $(document).ready(function () {
           dt.rows({ selected: true }).every(function() {
             kits.push(this.data()[0]);
           });
-          $.post('/ag_view_handout/', {kits: JSON.stringify(kits)})
-            .done(function(data) {
-              if (data == 'Success') {
-                history.go(0);
-              } else {
-                alert(data);
-              }
-            });
+
+          if (confirm("Are you sure you want to delete " + kits.length + " kits?")) {
+            $.post('/ag_view_handout/', {kits: JSON.stringify(kits)})
+              .done(function(data) {
+                if (data == 'Success') {
+                  history.go(0);
+                } else {
+                  alert(data);
+                }
+              });
+          }
         }
       }
     ]

--- a/knimin/templates/auth_sitebase.html
+++ b/knimin/templates/auth_sitebase.html
@@ -36,6 +36,7 @@
             {% if admin or db.has_access(current_user, ['Create AG kits']) %}
             <li><a href="/ag_new_kit/">Add New AG kits</a></li>
             <li><a href="/ag_add_barcode_kit/">Add Barcodes to AG Kits</a></li>
+            <li><a href="/ag_view_handout/">View/edit AG handout kits</a></li>
             {% end %}
             {% if admin or db.has_access(current_user, ['Add external surveys'])%}
             <li><a href="/ag_third_party/add/">Add External Survey</a></li>

--- a/knimin/templates/auth_sitebase.html
+++ b/knimin/templates/auth_sitebase.html
@@ -36,7 +36,6 @@
             {% if admin or db.has_access(current_user, ['AG kits']) %}
             <li><a href="/ag_new_kit/">Add New AG kits</a></li>
             <li><a href="/ag_add_barcode_kit/">Add Barcodes to AG Kits</a></li>
-            <li><a href="/ag_view_handout/">View/edit AG handout kits</a></li>
             {% end %}
             {% if admin or db.has_access(current_user, ['External surveys'])%}
             <li><a href="/ag_third_party/add/">Add External Survey</a></li>
@@ -46,6 +45,7 @@
             <li><a href="/ag_pulldown/">Metadata Pulldown</a></li>
             {% end %}
             {% if admin %}
+            <li><a href="/ag_view_handout/">View/edit AG handout kits</a></li>
             <li><a href="/ag_participant_names/">Participant Names</a></li>
             {% end %}
         </ul>

--- a/knimin/webserver.py
+++ b/knimin/webserver.py
@@ -32,6 +32,7 @@ from knimin.handlers.ag_third_party import (AGThirdPartyHandler,
 from knimin.handlers.ag_consent_check import AGConsentCheckHandler
 from knimin.handlers.projects_summary import ProjectsSummaryHandler
 from knimin.handlers.access_control import AGEditAccessHandler
+from knimin.handlers.ag_view_handout import AGViewHandoutHandler
 define("port", default=config.http_port, type=int)
 
 
@@ -61,6 +62,7 @@ class WebApplication(Application):
             (r"/ag_edit_kit/", AGEditKitHandler),
             (r"/ag_new_barcode/", AGNewBarcodeHandler),
             (r"/ag_update_geocode/", AGUpdateGeocodeHandler),
+            (r"/ag_view_handout/", AGViewHandoutHandler),
             (r"/update_ebi/", UpdateEBIStatusHandler),
             (r"/ag_edit_barcode/", AGEditBarcodeHandler),
             (r"/ag_pulldown/", AGPulldownHandler),


### PR DESCRIPTION
This adds a listing of all handout kits in the system, using DataTables, that can be exported to excel format or used to delete errant kits. 

Requires #55 
