### PR TITLE
Fixing pulldown

### DIFF
--- a/knimin/lib/data_access.py
+++ b/knimin/lib/data_access.py
@@ -1122,6 +1122,8 @@ class KniminAccess(object):
                         ext_survey_sql, [ext])
                     headers.union(self._convert_header(ext, h[0])
                                   for h in ext_headers)
+            # Remove the ebi prohibited columns
+            headers = headers.difference(ebi_remove)
             headers = sorted(headers)
             survey_md = [''.join(['sample_name\t', '\t'.join(headers)])]
 

--- a/knimin/lib/tests/test_data_access.py
+++ b/knimin/lib/tests/test_data_access.py
@@ -6,6 +6,7 @@ import datetime
 import pandas as pd
 
 from knimin import db
+from knimin.lib.constants import ebi_remove
 
 
 class TestDataAccess(TestCase):
@@ -41,6 +42,11 @@ class TestDataAccess(TestCase):
         survey_df = pd.read_csv(
             StringIO(obs[1]), delimiter='\t', dtype=str, encoding='utf-8')
         survey_df.set_index('sample_name', inplace=True, drop=True)
+
+        # Make sure that the prohibited columns from EBI are not in the
+        # pulldown
+        self.assertEqual(set(survey_df.columns).intersection(ebi_remove),
+                         set())
 
         freq_accepted_vals = {
             'Never', 'Rarely (a few times/month)',


### PR DESCRIPTION
While testing on the test environment we realized that the columns not allowed by EBI where added to the pulldown. Although those columns were always containing only the value "Unspecified" (i.e. they did not contain real data), those columns should not be there.

@wasade, are you able to take a quick review?