### PR TITLE
Unittest squash barcodes

### DIFF
--- a/knimin/lib/squash_barcodes.py
+++ b/knimin/lib/squash_barcodes.py
@@ -92,7 +92,7 @@ def build_barcodes_pdf(barcodes):
     tmpdir = "tmp_%s" % ''.join([choice("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
                                  for i in range(5)])
     # TODO: leverage python's tempfile module to replace this home brew
-    # mechanism here. See issue #147.
+    # mechanism here. See issue: #147.
     while path.exists(tmpdir):
         tmpdir = "tmp_%s" % ''.join([choice("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
                                      for i in range(5)])

--- a/knimin/lib/squash_barcodes.py
+++ b/knimin/lib/squash_barcodes.py
@@ -91,6 +91,8 @@ def build_barcodes_pdf(barcodes):
     # write out each page
     tmpdir = "tmp_%s" % ''.join([choice("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
                                  for i in range(5)])
+    # TODO: leverage python's tempfile module to replace this home brew
+    # mechanism here. See issue #147.
     while path.exists(tmpdir):
         tmpdir = "tmp_%s" % ''.join([choice("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
                                      for i in range(5)])

--- a/knimin/lib/tests/test_squash_barcodes.py
+++ b/knimin/lib/tests/test_squash_barcodes.py
@@ -15,9 +15,9 @@ class SquashBarcodesTests(TestCase):
 
         # replace get_image method to change behaviour
         def mock_get_image1(barcodes):
-            font = join(dirname(realpath(knimin.lib.__file__)), 'FreeSans.ttf')
+            font = join(dirname(realpath(__file__)), '../', 'FreeSans.ttf')
             for b in barcodes:
-                yield code128_image(b, height=150, width=300, font=font
+                yield code128_image(b, height=150, width=300, font=font,
                                     thickness=2, show_text=True,
                                     quiet_zone=False)
         m.get_image = mock_get_image1
@@ -25,7 +25,7 @@ class SquashBarcodesTests(TestCase):
 
         # replace get_image method to change behaviour
         def mock_get_image2(barcodes):
-            font = join(dirname(realpath(knimin.lib.__file__)), 'FreeSans.ttf')
+            font = join(dirname(realpath(__file__)), '../', 'FreeSans.ttf')
             for b in barcodes:
                 yield code128_image(b, height=150, width=303, font=font,
                                     thickness=2, show_text=True,

--- a/knimin/lib/tests/test_squash_barcodes.py
+++ b/knimin/lib/tests/test_squash_barcodes.py
@@ -21,7 +21,7 @@ class SquashBarcodesTests(TestCase):
                                     thickness=2, show_text=True,
                                     quiet_zone=False)
         m.get_image = mock_get_image1
-        self.assertIn('Length 10943', m.build_barcodes_pdf(['000000011']))
+        self.assertIn('%PDF-1.4\n%', m.build_barcodes_pdf(['000000011']))
 
         # replace get_image method to change behaviour
         def mock_get_image2(barcodes):

--- a/knimin/lib/tests/test_squash_barcodes.py
+++ b/knimin/lib/tests/test_squash_barcodes.py
@@ -15,15 +15,17 @@ class SquashBarcodesTests(TestCase):
 
         # replace get_image method to change behaviour
         def mock_get_image1(barcodes):
+            font = join(dirname(realpath(knimin.lib.__file__)), 'FreeSans.ttf')
             for b in barcodes:
-                yield code128_image(b, height=150, width=300, thickness=2,
-                                    show_text=True, quiet_zone=False)
+                yield code128_image(b, height=150, width=300, font=font
+                                    thickness=2, show_text=True,
+                                    quiet_zone=False)
         m.get_image = mock_get_image1
         self.assertIn('Length 10943', m.build_barcodes_pdf(['000000011']))
 
         # replace get_image method to change behaviour
         def mock_get_image2(barcodes):
-            font = join(dirname(realpath(__file__)), 'FreeSans.ttf')
+            font = join(dirname(realpath(knimin.lib.__file__)), 'FreeSans.ttf')
             for b in barcodes:
                 yield code128_image(b, height=150, width=303, font=font,
                                     thickness=2, show_text=True,


### PR DESCRIPTION
To check all conditions in the build_barcodes_pdf method, I had to dynamically replace the get_image method. Thus, I needed to change how those methods are imported.