### PR TITLE
Plate mapper 03 added sample plate and layout

### DIFF
--- a/knimin/lib/data_access.py
+++ b/knimin/lib/data_access.py
@@ -2426,16 +2426,18 @@ class KniminAccess(object):
 
         Parameters
         ----------
-        qiita_study_id : int
-        title : str
-        skip_id : int
-            Skip this ID in searching
+        qiita_study_id : int, optional
+        title : str, optional
+            Either qiita_study_id or title must be given to identify a study
+        skip_id : int, optional
+            Skip this study ID in searching
+            In function create_study, this is not used
+            In function edit_study, this is the current study to be edited
 
         Raises
         ------
         ValueError
-            If neither value is specified, or
-            If either value already exists
+            If neither value is given, or either value already exists
         """
         tags = ['Qiita study ID', 'Title']
         cols = [tag.lower().replace(' ', '_') for tag in tags]
@@ -2473,10 +2475,11 @@ class KniminAccess(object):
 
         Parameters
         ----------
-        qiita_study_id : int
-        title : str
-        alias : str
-        notes : str
+        qiita_study_id : int, optional
+        title : str, optional
+            Either qiita_study_id or title must be specified
+        alias : str, optional
+        notes : str, optional
 
         Returns
         -------
@@ -2500,10 +2503,11 @@ class KniminAccess(object):
         ----------
         study_id : int
             ID of the study to edit
-        qiita_study_id : int
-        title : str
-        alias : str
-        notes : str
+        qiita_study_id : int, optional
+        title : str, optional
+            Either qiita_study_id or title must be specified
+        alias : str, optional
+        notes : str, optional
         """
         self._study_exists(study_id)
         self._study_is_unique(qiita_study_id, title, study_id)
@@ -2595,10 +2599,10 @@ class KniminAccess(object):
         ----------
         samples : list of dict
             {
-             id : str (mandatory),
-             is_blank : bool (optional, default: False),
-             barcode : str (optional),
-             notes : str (optional)
+             id : str,
+             is_blank : bool, optional, default: False,
+             barcode : str, optional,
+             notes : str, optional
             }
 
         Raises
@@ -2632,9 +2636,9 @@ class KniminAccess(object):
             {
              id : str,
                 ID of the sample to edit
-             is_blank : bool (optional, default: False),
-             barcode : str (optional),
-             notes : str (optional)
+             is_blank : bool, optional, default: False,
+             barcode : str, optional,
+             notes : str, optional
             }
 
         Raises
@@ -2746,7 +2750,7 @@ class KniminAccess(object):
         Parameters
         ----------
         name : str
-        skip_id : int
+        skip_id : int, optional
             Skip this ID in searching
 
         Raises
@@ -2768,7 +2772,7 @@ class KniminAccess(object):
 
         Parameters
         ----------
-        barcode : str
+        email : str
 
         Raises
         ------
@@ -2780,14 +2784,13 @@ class KniminAccess(object):
         if not self._con.execute_fetchone(sql, [email])[0]:
             raise ValueError('Email %s does not exist.' % email)
 
-    def _plate_type_name_to_id(self, name):
+    def _plate_type_name_to_id(self, name=None):
         """Gets plate type ID by name
 
         Parameters
         ----------
-        name : str
-            Name of the plate type. If None, ID of the first plate type (i.e.,
-            96-well) will return
+        name : str, optional
+            Plate type name. If None, the first plate type will be selected
 
         Returns
         -------
@@ -2821,11 +2824,11 @@ class KniminAccess(object):
         Parameters
         ----------
         name : str
-        email : str
-        created_on: datetime
-        notes : str
-        plate_type : str
-            If None, the first plate type (i.e., 96-well) will be used
+        email : str, optional
+        created_on: datetime, optional
+        notes : str, optional
+        plate_type : str, optional
+            If None, the first plate type will be used
 
         Returns
         -------
@@ -2854,14 +2857,16 @@ class KniminAccess(object):
         id : int
             ID of the sample plate to edit
         name : str
-        email : str
-        created_on: datetime
-        notes : str
-        plate_type : str
-            If None, the first plate type (i.e., 96-well) will be used
+        email : str, optional
+        created_on: datetime, optional
+        notes : str, optional
+        plate_type : str, optional
+            If None, the first plate type will be used
         """
         self._sample_plate_exists(id)
         self._sample_plate_is_unique(name, id)
+        if email:
+            self._email_exists(email)
         plate_type_id = self._plate_type_name_to_id(plate_type)
         with TRN:
             sql = """UPDATE pm.sample_plate

--- a/knimin/lib/data_access.py
+++ b/knimin/lib/data_access.py
@@ -2973,11 +2973,6 @@ class KniminAccess(object):
         Parameters
         ----------
         id : int
-
-        Returns
-        -------
-        bool
-            True if successful
         """
         self._sample_plate_exists(id)
         if self._sample_plate_layout_exists(id):

--- a/knimin/lib/tests/test_data_access.py
+++ b/knimin/lib/tests/test_data_access.py
@@ -586,7 +586,7 @@ class TestDataAccess(TestCase):
         db.delete_sample_plate(spid2)
         # Attempt to assign an invalid email to a sample plate
         with self.assertRaises(ValueError) as context:
-            db.edit_sample_plate(spid, email='not-an-email')
+            db.edit_sample_plate(spid, name='test_plate', email='not-an-email')
         err = 'Email not-an-email does not exist.'
         self.assertEqual(str(context.exception), err)
         # Attempt to edit a sample plate that does not exist

--- a/knimin/lib/tests/test_data_access.py
+++ b/knimin/lib/tests/test_data_access.py
@@ -543,6 +543,14 @@ class TestDataAccess(TestCase):
         self.assertGreater(spid, 0)
         obs = db.read_sample_plate(spid)
         self.assertDictEqual(obs, spinfo)
+        # Create a sample plate with the default plate type
+        spid2 = db.create_sample_plate('test_plate_2')
+        self.assertGreater(spid2, 0)
+        obs = db.read_sample_plate(spid2)
+        exp = {'name': 'test_plate_2', 'email': None, 'created_on': None,
+               'notes': None, 'plate_type': plate_type}
+        self.assertDictEqual(obs, exp)
+        db.delete_sample_plate(spid2)
         # Attempt to create a sample plate with a duplicate name
         with self.assertRaises(ValueError) as context:
             db.create_sample_plate(name='test_plate')
@@ -553,6 +561,12 @@ class TestDataAccess(TestCase):
         with self.assertRaises(ValueError) as context:
             db.create_sample_plate(name='test_plate_2', email='not-an-email')
         err = 'Email not-an-email does not exist.'
+        self.assertEqual(str(context.exception), err)
+        # Attempt to create a sample plate with an invalid plate type
+        with self.assertRaises(ValueError) as context:
+            db.create_sample_plate(name='test_plate_2',
+                                   plate_type='not-a-plate-type')
+        err = 'Plate type \'not-a-plate-type\' does not exist.'
         self.assertEqual(str(context.exception), err)
         db.delete_sample_plate(spid)
 


### PR DESCRIPTION
Here are some new functions that handle "sample_plate" and "sample_plate_layout". They work seamlessly. Deleting a sample plate will also delete its associated layout. I also edited the "delete_samples" function. It will raise error if the sample is found to be associated with a sample plate.