### PR TITLE
changed test for PDF generation

### DIFF
--- a/knimin/lib/tests/test_squash_barcodes.py
+++ b/knimin/lib/tests/test_squash_barcodes.py
@@ -13,7 +13,7 @@ class SquashBarcodesTests(TestCase):
 
         old_get_image = m.get_image
 
-        # replace get_image method to change behaviour
+        # replace get_image method to change behaviour.
         def mock_get_image1(barcodes):
             font = join(dirname(realpath(__file__)), '../', 'FreeSans.ttf')
             for b in barcodes:

--- a/knimin/lib/tests/test_squash_barcodes.py
+++ b/knimin/lib/tests/test_squash_barcodes.py
@@ -9,7 +9,7 @@ import knimin.lib.squash_barcodes as m
 
 class SquashBarcodesTests(TestCase):
     def test_build_barcodes_pdf(self):
-        self.assertIn('Length 10559', m.build_barcodes_pdf(['000000011']))
+        self.assertIn('%PDF-1.4\n%', m.build_barcodes_pdf(['000000011']))
 
         old_get_image = m.get_image
 


### PR DESCRIPTION
I am trying to test if a PDF file has been generated. I am checking for some strings in the text representation of the PDF. It turns out that the content changes with used font. Thus, I should no longer check for the string "Length 10559" but for something stable.
Now, tests should pass again.