### PR TITLE
updated expectation for one geocoder test

### DIFF
--- a/knimin/lib/tests/test_geocoder.py
+++ b/knimin/lib/tests/test_geocoder.py
@@ -86,8 +86,8 @@ class TestGeocode(TestCase):
         self.assertEqual(obs.country, exp.country)
 
         # Test for unicode
-        obs = geocode('12 Erlangen')
-        exp = Location('12 Erlangen', 59.36121550000001, 16.4908829,
+        obs = geocode('Erlangengatan 12')
+        exp = Location('Erlangengatan 12', 59.36121550000001, 16.4908829,
                        38.21769714355469, 'Eskilstuna',
                        u'S\xf6dermanlands l\xe4n', '632 30', 'Sweden')
         self.assertEqual(obs, exp)


### PR DESCRIPTION
I think the test is broken. The expected location is a street in the Swedish city Eskilstuna. The actual street name is "Erlangengatan 12" not "12 Erlangen". However, there is a German city called "Erlangen". I guess that google updated it's approximate search such that it now gives precedence to a matching city name, rather to a misspelled Street name.

Thus, I tend to say that we have to correct our expectation in the test. Could you make this change? I suggest to replace '12 Erlangen' by 'Erlangengatan 12'.