### PR TITLE
"Project" unicode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ addons:
   postgresql: "9.3"
 before_install:
   - redis-server --version
-  - conda list
 install:
   - pip install --upgrade pip
   - pip install click natsort coverage coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
   postgresql: "9.3"
 before_install:
   - redis-server --version
+  - conda list
 install:
   - pip install --upgrade pip
   - pip install click natsort coverage coveralls

--- a/knimin/handlers/ag_new_barcode.py
+++ b/knimin/handlers/ag_new_barcode.py
@@ -69,10 +69,9 @@ class AGNewBarcodeHandler(BaseHandler):
                    % num_barcodes)
 
         elif action == "assign":
-            prj = self.get_argument('projects')
-            print('ARGUMENT', prj, type(prj))
-            projects = map(url_unescape,
-                           self.get_argument('projects').split(','))
+            projects = self.get_arguments('projects')
+            if projects != []:
+                projects = list(map(url_unescape, projects[0].split(',')))
             new_project = url_unescape(self.get_argument('newproject').strip())
             try:
                 if new_project:

--- a/knimin/handlers/ag_new_barcode.py
+++ b/knimin/handlers/ag_new_barcode.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from tornado.web import authenticated, HTTPError
-from tornado.escape import xhtml_escape, url_unescape
+from tornado.escape import xhtml_escape
 from knimin.handlers.base import BaseHandler
 from knimin.handlers.access_decorators import set_access
 

--- a/knimin/handlers/ag_new_kit.py
+++ b/knimin/handlers/ag_new_kit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from json import loads
 from tornado.web import authenticated, HTTPError
-from tornado.escape import url_unescape, xhtml_escape
+from tornado.escape import xhtml_escape
 from knimin.handlers.base import BaseHandler
 from knimin.handlers.access_decorators import set_access
 from knimin import db

--- a/knimin/handlers/ag_new_kit.py
+++ b/knimin/handlers/ag_new_kit.py
@@ -47,7 +47,9 @@ class AGNewKitHandler(BaseHandler):
         tag = self.get_argument("tag")
         if not tag:
             tag = None
-        projects = list(map(url_unescape, self.get_arguments("projects")))
+        projects = self.get_arguments("projects")
+        if projects != []:
+            projects = list(map(url_unescape, projects))
         num_swabs = map(int, self.get_arguments("swabs"))
         num_kits = map(int, self.get_arguments("kits"))
         kits = []

--- a/knimin/handlers/ag_new_kit.py
+++ b/knimin/handlers/ag_new_kit.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from json import loads
 from tornado.web import authenticated, HTTPError
+from tornado.escape import url_unescape, xhtml_escape
 from knimin.handlers.base import BaseHandler
 from knimin.handlers.access_decorators import set_access
 from knimin import db
@@ -35,7 +36,7 @@ class AGNewKitDLHandler(BaseHandler):
 class AGNewKitHandler(BaseHandler):
     @authenticated
     def get(self):
-        project_names = db.getProjectNames()
+        project_names = list(map(xhtml_escape, db.getProjectNames()))
         remaining = len(db.get_unassigned_barcodes())
         self.render("ag_new_kit.html", projects=project_names,
                     currentuser=self.current_user, msg="", kitinfo=[],
@@ -46,7 +47,7 @@ class AGNewKitHandler(BaseHandler):
         tag = self.get_argument("tag")
         if not tag:
             tag = None
-        projects = self.get_arguments("projects")
+        projects = list(map(url_unescape, self.get_arguments("projects")))
         num_swabs = map(int, self.get_arguments("swabs"))
         num_kits = map(int, self.get_arguments("kits"))
         kits = []

--- a/knimin/handlers/ag_new_kit.py
+++ b/knimin/handlers/ag_new_kit.py
@@ -48,8 +48,6 @@ class AGNewKitHandler(BaseHandler):
         if not tag:
             tag = None
         projects = self.get_arguments("projects")
-        if projects != []:
-            projects = list(map(url_unescape, projects))
         num_swabs = map(int, self.get_arguments("swabs"))
         num_kits = map(int, self.get_arguments("kits"))
         kits = []

--- a/knimin/handlers/barcode_util.py
+++ b/knimin/handlers/barcode_util.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from tornado.web import authenticated
-from tornado.escape import xhtml_escape, url_unescape
+from tornado.escape import xhtml_escape
 from knimin.handlers.base import BaseHandler
 from datetime import datetime
 
@@ -255,7 +255,7 @@ class BarcodeUtilHandler(BaseHandler, BarcodeUtilHelper):
                                                     None)
         sequencing_status = self.get_argument('sequencing_status', None)
         obsolete_status = self.get_argument('obsolete_status', None)
-        projects = set(map(url_unescape, self.get_arguments('project')))
+        projects = set(self.get_arguments('project'))
         sent_date = self.get_argument('sent_date', None)
         login_user = self.get_argument('login_user',
                                        'American Gut participant')

--- a/knimin/handlers/barcode_util.py
+++ b/knimin/handlers/barcode_util.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from tornado.web import authenticated
+from tornado.escape import xhtml_escape, url_unescape
 from knimin.handlers.base import BaseHandler
 from datetime import datetime
 
@@ -202,6 +203,12 @@ class BarcodeUtilHandler(BaseHandler, BarcodeUtilHelper):
         barcode_projects, parent_project = db.getBarcodeProjType(
             barcode)
         project_names = db.getProjectNames()
+        # xhtml escape project names
+        barcode_projects = ", ".join(map(xhtml_escape,
+                                         barcode_projects.split(', ')))
+        parent_project = ", ".join(map(xhtml_escape,
+                                       parent_project.split(', ')))
+        project_names = list(map(xhtml_escape, project_names))
 
         # barcode exists get general info
         # TODO (Stefan Janssen): check spelling of "received", i.e. tests in
@@ -248,7 +255,7 @@ class BarcodeUtilHandler(BaseHandler, BarcodeUtilHelper):
                                                     None)
         sequencing_status = self.get_argument('sequencing_status', None)
         obsolete_status = self.get_argument('obsolete_status', None)
-        projects = set(self.get_arguments('project'))
+        projects = set(map(url_unescape, self.get_arguments('project')))
         sent_date = self.get_argument('sent_date', None)
         login_user = self.get_argument('login_user',
                                        'American Gut participant')

--- a/knimin/handlers/projects_summary.py
+++ b/knimin/handlers/projects_summary.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from tornado.web import authenticated
+from tornado.escape import xhtml_escape
 from knimin.handlers.base import BaseHandler
 from knimin.handlers.access_decorators import set_access
 from knimin import db
@@ -10,5 +11,7 @@ class ProjectsSummaryHandler(BaseHandler):
     @authenticated
     def get(self):
         projects = db.getProjectNames()
-        info = [(p, len(db.get_barcodes_for_projects([p]))) for p in projects]
+        # escape unicode project names for xhtml rendering
+        info = [(xhtml_escape(p), len(db.get_barcodes_for_projects([p])))
+                for p in projects]
         self.render('projects_summary.html', proj_counts=info)

--- a/knimin/lib/data_access.py
+++ b/knimin/lib/data_access.py
@@ -1500,7 +1500,8 @@ class KniminAccess(object):
         sql = "SELECT EXISTS(SELECT * FROM project WHERE project = %s)"
         exists = self._con.execute_fetchone(sql, [name])[0]
         if exists:
-                raise ValueError("Project %s already exists!" % name)
+                raise ValueError("Project %s already exists!" %
+                                 xhtml_escape(name))
 
         sql = """INSERT INTO project (project_id, project)
                  SELECT max(project_id)+1, %s FROM project"""

--- a/knimin/lib/data_access.py
+++ b/knimin/lib/data_access.py
@@ -20,6 +20,7 @@ from mail import send_email
 from util import (make_valid_kit_ids, make_verification_code, make_passwd,
                   categorize_age, categorize_etoh, categorize_bmi, correct_age,
                   fetch_url, correct_bmi)
+from tornado.escape import xhtml_escape
 from constants import (md_lookup, month_int_lookup, month_str_lookup,
                        regions_by_state, blanks_values, season_lookup,
                        ebi_remove, env_lookup)
@@ -1567,7 +1568,7 @@ class KniminAccess(object):
         not_exist = {p for p in projects if p not in existing}
         if not_exist:
             raise ValueError("Project(s) given don't exist in database: %s"
-                             % ', '.join(not_exist))
+                             % ', '.join(map(xhtml_escape, not_exist)))
 
         # Get unassigned barcode list and make sure we have enough barcodes
         barcodes = self.get_unassigned_barcodes(num_barcodes)

--- a/knimin/lib/tests/test_geocoder.py
+++ b/knimin/lib/tests/test_geocoder.py
@@ -93,9 +93,11 @@ class TestGeocode(TestCase):
         self.assertEqual(obs, exp)
 
     def test_geocode_bad_address(self):
-        obs = geocode('SomeRandomPlace')
-        exp = Location('SomeRandomPlace', None, None, None, None, None, None,
-                       None)
+        # google always tried to find something, thus make sure this is really
+        # not a word or something that can be matched somehow.
+        loc_name = 'SomeRdfkcmolzscrmilxsrhi,luxrg,zshandomPlace'
+        obs = geocode(loc_name)
+        exp = Location(loc_name, None, None, None, None, None, None, None)
         self.assertEqual(obs, exp)
 
 

--- a/knimin/tests/test_ag_new_barcode.py
+++ b/knimin/tests/test_ag_new_barcode.py
@@ -136,29 +136,28 @@ class TestAGNewBarcodeHandler(TestHandlerBase):
                              {'action': 'assign',
                               'numbarcodes': num_barcodes,
                               'newproject': url_escape(projects[0])})
-        print(response.body)
-        # self.assertEqual(response.code, 200)
-        # self.assertIn("ERROR! Project %s already exists!" %
-        #               xhtml_escape(projects[0]),
-        #               response.body)
-        #
-        # # check recognition of unkown action
-        # response = self.post('/ag_new_barcode/', {'action': 'unkown'})
-        # self.assertEqual(response.code, 400)
-        # self.assertRaises(HTTPError)
-        #
-        # # test that new project is appended to list of projects
-        # response = self.post('/ag_new_barcode/',
-        #                      {'action': 'assign',
-        #                       'numbarcodes': num_barcodes,
-        #                       'projects': ','.join(
-        #                         list(map(url_escape, projects))),
-        #                       'newproject': url_escape(newProject)})
-        # self.assertEqual(response.code, 200)
-        # self.assertIn("%i barcodes assigned to %s, please wait for download." %
-        #               (num_barcodes, ", ".join(map(xhtml_escape,
-        #                                            projects + [newProject]))),
-        #               response.body)
+        self.assertEqual(response.code, 200)
+        self.assertIn("ERROR! Project %s already exists!" %
+                      xhtml_escape(projects[0]),
+                      response.body)
+
+        # check recognition of unkown action
+        response = self.post('/ag_new_barcode/', {'action': 'unkown'})
+        self.assertEqual(response.code, 400)
+        self.assertRaises(HTTPError)
+
+        # test that new project is appended to list of projects
+        response = self.post('/ag_new_barcode/',
+                             {'action': 'assign',
+                              'numbarcodes': num_barcodes,
+                              'projects': ','.join(
+                                list(map(url_escape, projects))),
+                              'newproject': url_escape(newProject)})
+        self.assertEqual(response.code, 200)
+        self.assertIn("%i barcodes assigned to %s, please wait for download." %
+                      (num_barcodes, ", ".join(map(xhtml_escape,
+                                                   projects + [newProject]))),
+                      response.body)
 
 
 if __name__ == "__main__":

--- a/knimin/tests/test_ag_new_barcode.py
+++ b/knimin/tests/test_ag_new_barcode.py
@@ -36,10 +36,11 @@ class TestAGBarcodeAssignedHandler(TestHandlerBase):
         projects = ["American Gut Project", "Autism Spectrum Disorder"]
         barcodes = ["1111", "222", "33", "4"]
         response = self.post('/ag_new_barcode/assigned/',
-                             {'barcodes': ",".join(barcodes),
-                              'projects': ",".join(map(url_escape, projects))})
+                             {'barcodes': barcodes,
+                              'projects': projects})
         self.assertEqual(response.code, 200)
-        text = "".join(["%s\t%s\n" % (b, ",".join(map(xhtml_escape, projects)))
+        text = "".join(["%s\t%s\n" % (xhtml_escape(b),
+                                      ",".join(map(xhtml_escape, projects)))
                         for b in barcodes])
         self.assertEqual(response.body, text)
 
@@ -90,7 +91,7 @@ class TestAGNewBarcodeHandler(TestHandlerBase):
         response = self.post('/ag_new_barcode/',
                              {'action': 'assign',
                               'numbarcodes': num_barcodes,
-                              'projects': ",".join(map(url_escape, projects))})
+                              'projects': projects})
 
         # check assignment of barcodes
         # check that error is raised if project(s) cannot be found in DB
@@ -98,9 +99,7 @@ class TestAGNewBarcodeHandler(TestHandlerBase):
         response = self.post('/ag_new_barcode/',
                              {'action': 'assign',
                               'numbarcodes': num_barcodes,
-                              'projects': ","
-                              .join(map(url_escape,
-                                        projects + [prj_nonexist])),
+                              'projects': projects + [prj_nonexist],
                               'newproject': ""})
         self.assertEqual(response.code, 200)
         exp = ('<h3>ERROR! Project(s) given don\'t exist in database: '
@@ -111,8 +110,7 @@ class TestAGNewBarcodeHandler(TestHandlerBase):
         response = self.post('/ag_new_barcode/',
                              {'action': 'assign',
                               'numbarcodes': num_barcodes,
-                              'projects': ','.join(
-                                list(map(url_escape, projects))),
+                              'projects': projects,
                               'newproject': ""})
         self.assertEqual(response.code, 200)
         self.assertIn("%i barcodes assigned to %s, please wait for download." %
@@ -124,8 +122,7 @@ class TestAGNewBarcodeHandler(TestHandlerBase):
         response = self.post('/ag_new_barcode/',
                              {'action': 'assign',
                               'numbarcodes': 0,
-                              'projects': ','.join(
-                                list(map(url_escape, projects))),
+                              'projects': projects,
                               'newproject': ""})
         self.assertEqual(response.code, 200)
         self.assertIn("Error running SQL query: UPDATE barcodes.barcode",
@@ -135,7 +132,7 @@ class TestAGNewBarcodeHandler(TestHandlerBase):
         response = self.post('/ag_new_barcode/',
                              {'action': 'assign',
                               'numbarcodes': num_barcodes,
-                              'newproject': url_escape(projects[0])})
+                              'newproject': projects[0]})
         self.assertEqual(response.code, 200)
         self.assertIn("ERROR! Project %s already exists!" %
                       xhtml_escape(projects[0]),
@@ -150,9 +147,8 @@ class TestAGNewBarcodeHandler(TestHandlerBase):
         response = self.post('/ag_new_barcode/',
                              {'action': 'assign',
                               'numbarcodes': num_barcodes,
-                              'projects': ','.join(
-                                list(map(url_escape, projects))),
-                              'newproject': url_escape(newProject)})
+                              'projects': projects,
+                              'newproject': newProject})
         self.assertEqual(response.code, 200)
         self.assertIn("%i barcodes assigned to %s, please wait for download." %
                       (num_barcodes, ", ".join(map(xhtml_escape,

--- a/knimin/tests/test_ag_new_barcode.py
+++ b/knimin/tests/test_ag_new_barcode.py
@@ -1,7 +1,7 @@
 from unittest import main
 import os
 
-from tornado.escape import url_escape
+from tornado.escape import url_escape, xhtml_escape
 from tornado.httpclient import HTTPError
 
 from knimin.tests.tornado_test_base import TestHandlerBase
@@ -37,9 +37,9 @@ class TestAGBarcodeAssignedHandler(TestHandlerBase):
         barcodes = ["1111", "222", "33", "4"]
         response = self.post('/ag_new_barcode/assigned/',
                              {'barcodes': ",".join(barcodes),
-                              'projects': ",".join(projects)})
+                              'projects': ",".join(map(url_escape, projects))})
         self.assertEqual(response.code, 200)
-        text = "".join(["%s\t%s\n" % (b, ",".join(projects))
+        text = "".join(["%s\t%s\n" % (b, ",".join(map(xhtml_escape, projects)))
                         for b in barcodes])
         self.assertEqual(response.body, text)
 
@@ -60,7 +60,7 @@ class TestAGNewBarcodeHandler(TestHandlerBase):
 
         for project in db.getProjectNames():
             self.assertIn("<option value='%s'>%s</option>" %
-                          (project, project), response.body)
+                          ((xhtml_escape(project),) * 2), response.body)
         self.assertIn("Number of barcodes (%i unassigned)" %
                       len(db.get_unassigned_barcodes()), response.body)
 
@@ -90,35 +90,42 @@ class TestAGNewBarcodeHandler(TestHandlerBase):
         response = self.post('/ag_new_barcode/',
                              {'action': 'assign',
                               'numbarcodes': num_barcodes,
-                              'projects': ",".join(projects)})
+                              'projects': ",".join(map(url_escape, projects))})
 
         # check assignment of barcodes
         # check that error is raised if project(s) cannot be found in DB
+        prj_nonexist = 'a non existing project name'
         response = self.post('/ag_new_barcode/',
                              {'action': 'assign',
                               'numbarcodes': num_barcodes,
-                              'projects': ",".join(projects),
+                              'projects': ","
+                              .join(map(url_escape,
+                                        projects + [prj_nonexist])),
                               'newproject': ""})
         self.assertEqual(response.code, 200)
-        self.assertIn(('<h3>ERROR! Project(s) given don\'t exist in database: '
-                       '%s</h3>') % (",".join(projects)), response.body)
+        exp = ('<h3>ERROR! Project(s) given don\'t exist in database: '
+               '%s</h3>') % xhtml_escape(prj_nonexist)
+        self.assertIn(exp, response.body)
 
         # check correct assignment report on HTML side
         response = self.post('/ag_new_barcode/',
                              {'action': 'assign',
                               'numbarcodes': num_barcodes,
-                              'projects': projects,
+                              'projects': ','.join(
+                                list(map(url_escape, projects))),
                               'newproject': ""})
         self.assertEqual(response.code, 200)
         self.assertIn("%i barcodes assigned to %s, please wait for download." %
-                      (num_barcodes, ", ".join(projects)), response.body)
+                      (num_barcodes, ", ".join(map(xhtml_escape, projects))),
+                      response.body)
 
         # check if SQL error is thrown if number of barcodes is 0.
         # See issue: #107
         response = self.post('/ag_new_barcode/',
                              {'action': 'assign',
                               'numbarcodes': 0,
-                              'projects': projects,
+                              'projects': ','.join(
+                                list(map(url_escape, projects))),
                               'newproject': ""})
         self.assertEqual(response.code, 200)
         self.assertIn("Error running SQL query: UPDATE barcodes.barcode",
@@ -128,26 +135,30 @@ class TestAGNewBarcodeHandler(TestHandlerBase):
         response = self.post('/ag_new_barcode/',
                              {'action': 'assign',
                               'numbarcodes': num_barcodes,
-                              'newproject': projects[0]})
-        self.assertEqual(response.code, 200)
-        self.assertIn("ERROR! Project %s already exists!" % projects[0],
-                      response.body)
-
-        # check recognition of unkown action
-        response = self.post('/ag_new_barcode/', {'action': 'unkown'})
-        self.assertEqual(response.code, 400)
-        self.assertRaises(HTTPError)
-
-        # test that new project is appended to list of projects
-        response = self.post('/ag_new_barcode/',
-                             {'action': 'assign',
-                              'numbarcodes': num_barcodes,
-                              'projects': projects,
-                              'newproject': newProject})
-        self.assertEqual(response.code, 200)
-        self.assertIn("%i barcodes assigned to %s, please wait for download." %
-                      (num_barcodes, ", ".join(projects + [newProject])),
-                      response.body)
+                              'newproject': url_escape(projects[0])})
+        print(response.body)
+        # self.assertEqual(response.code, 200)
+        # self.assertIn("ERROR! Project %s already exists!" %
+        #               xhtml_escape(projects[0]),
+        #               response.body)
+        #
+        # # check recognition of unkown action
+        # response = self.post('/ag_new_barcode/', {'action': 'unkown'})
+        # self.assertEqual(response.code, 400)
+        # self.assertRaises(HTTPError)
+        #
+        # # test that new project is appended to list of projects
+        # response = self.post('/ag_new_barcode/',
+        #                      {'action': 'assign',
+        #                       'numbarcodes': num_barcodes,
+        #                       'projects': ','.join(
+        #                         list(map(url_escape, projects))),
+        #                       'newproject': url_escape(newProject)})
+        # self.assertEqual(response.code, 200)
+        # self.assertIn("%i barcodes assigned to %s, please wait for download." %
+        #               (num_barcodes, ", ".join(map(xhtml_escape,
+        #                                            projects + [newProject]))),
+        #               response.body)
 
 
 if __name__ == "__main__":

--- a/knimin/tests/test_ag_new_kit.py
+++ b/knimin/tests/test_ag_new_kit.py
@@ -58,12 +58,10 @@ class TestAGNewKitHandler(TestHandlerBase):
         # check for correct results
         response = self.post('/ag_new_kit/',
                              {'tag': tag,
-                              'projects': list(map(url_escape,
-                                                   ['PROJECT2', 'PROJECT5'])),
+                              'projects': ['PROJECT2', 'PROJECT5'],
                               'swabs': swabs,
                               'kits': kits,
                               })
-        print(response.body)
         kitinfo = loads(response.body)
         self.assertEqual(len(kitinfo['kitinfo']), sum(kits))
         for k in kitinfo['kitinfo']:
@@ -75,8 +73,7 @@ class TestAGNewKitHandler(TestHandlerBase):
 
         # missing argument
         response = self.post('/ag_new_kit/',
-                             {'projects': list(map(url_escape,
-                                                   ['PROJECT2', 'PROJECT5'])),
+                             {'projects': ['PROJECT2', 'PROJECT5'],
                               'swabs': swabs,
                               'kits': kits,
                               })
@@ -85,8 +82,7 @@ class TestAGNewKitHandler(TestHandlerBase):
         # too long tag
         response = self.post('/ag_new_kit/',
                              {'tag': 'toolongtag',
-                              'projects': list(map(url_escape,
-                                                   ['PROJECT2', 'PROJECT5'])),
+                              'projects': ['PROJECT2', 'PROJECT5'],
                               'swabs': swabs,
                               'kits': kits,
                               })
@@ -98,9 +94,7 @@ class TestAGNewKitHandler(TestHandlerBase):
         # test that non existing projects are recognized.
         response = self.post('/ag_new_kit/',
                              {'tag': 'abc',
-                              'projects': list(map(url_escape,
-                                                   ['doesNotExist',
-                                                    'PROJECT5'])),
+                              'projects': ['doesNotExist', 'PROJECT5'],
                               'swabs': swabs,
                               'kits': kits,
                               })
@@ -111,8 +105,7 @@ class TestAGNewKitHandler(TestHandlerBase):
         # check for empty swabs list
         response = self.post('/ag_new_kit/',
                              {'tag': tag,
-                              'projects': list(map(url_escape,
-                                                   ['PROJECT2', 'PROJECT5'])),
+                              'projects': ['PROJECT2', 'PROJECT5'],
                               'swabs': [],
                               'kits': kits,
                               })
@@ -123,8 +116,7 @@ class TestAGNewKitHandler(TestHandlerBase):
         # no kits given
         response = self.post('/ag_new_kit/',
                              {'tag': tag,
-                              'projects': list(map(url_escape,
-                                                   ['PROJECT2', 'PROJECT5'])),
+                              'projects': ['PROJECT2', 'PROJECT5'],
                               'swabs': swabs,
                               'kits': [],
                               })
@@ -135,8 +127,7 @@ class TestAGNewKitHandler(TestHandlerBase):
         # what if tag is None
         response = self.post('/ag_new_kit/',
                              {'tag': '',
-                              'projects': list(map(url_escape,
-                                                   ['PROJECT2', 'PROJECT5'])),
+                              'projects': ['PROJECT2', 'PROJECT5'],
                               'swabs': swabs,
                               'kits': kits,
                               })

--- a/knimin/tests/test_ag_new_kit.py
+++ b/knimin/tests/test_ag_new_kit.py
@@ -63,6 +63,7 @@ class TestAGNewKitHandler(TestHandlerBase):
                               'swabs': swabs,
                               'kits': kits,
                               })
+        print(response.body)
         kitinfo = loads(response.body)
         self.assertEqual(len(kitinfo['kitinfo']), sum(kits))
         for k in kitinfo['kitinfo']:

--- a/knimin/tests/test_ag_new_kit.py
+++ b/knimin/tests/test_ag_new_kit.py
@@ -1,6 +1,6 @@
 from unittest import main
 
-from tornado.escape import url_escape
+from tornado.escape import url_escape, xhtml_escape
 from json import loads, dumps
 
 from knimin.tests.tornado_test_base import TestHandlerBase
@@ -45,7 +45,7 @@ class TestAGNewKitHandler(TestHandlerBase):
         self.assertEqual(response.code, 200)
         for project in db.getProjectNames():
             self.assertIn("<option value='%s'>%s</option>" %
-                          (project, project), response.body)
+                          ((xhtml_escape(project),) * 2), response.body)
         self.assertIn("%i</span> unassigned barcodes" %
                       len(db.get_unassigned_barcodes()), response.body)
 
@@ -58,7 +58,8 @@ class TestAGNewKitHandler(TestHandlerBase):
         # check for correct results
         response = self.post('/ag_new_kit/',
                              {'tag': tag,
-                              'projects': ['PROJECT2', 'PROJECT5'],
+                              'projects': list(map(url_escape,
+                                                   ['PROJECT2', 'PROJECT5'])),
                               'swabs': swabs,
                               'kits': kits,
                               })
@@ -73,7 +74,8 @@ class TestAGNewKitHandler(TestHandlerBase):
 
         # missing argument
         response = self.post('/ag_new_kit/',
-                             {'projects': ['PROJECT2', 'PROJECT5'],
+                             {'projects': list(map(url_escape,
+                                                   ['PROJECT2', 'PROJECT5'])),
                               'swabs': swabs,
                               'kits': kits,
                               })
@@ -82,7 +84,8 @@ class TestAGNewKitHandler(TestHandlerBase):
         # too long tag
         response = self.post('/ag_new_kit/',
                              {'tag': 'toolongtag',
-                              'projects': ['PROJECT2', 'PROJECT5'],
+                              'projects': list(map(url_escape,
+                                                   ['PROJECT2', 'PROJECT5'])),
                               'swabs': swabs,
                               'kits': kits,
                               })
@@ -94,7 +97,9 @@ class TestAGNewKitHandler(TestHandlerBase):
         # test that non existing projects are recognized.
         response = self.post('/ag_new_kit/',
                              {'tag': 'abc',
-                              'projects': ['doesNotExist', 'PROJECT5'],
+                              'projects': list(map(url_escape,
+                                                   ['doesNotExist',
+                                                    'PROJECT5'])),
                               'swabs': swabs,
                               'kits': kits,
                               })
@@ -105,7 +110,8 @@ class TestAGNewKitHandler(TestHandlerBase):
         # check for empty swabs list
         response = self.post('/ag_new_kit/',
                              {'tag': tag,
-                              'projects': ['PROJECT2', 'PROJECT5'],
+                              'projects': list(map(url_escape,
+                                                   ['PROJECT2', 'PROJECT5'])),
                               'swabs': [],
                               'kits': kits,
                               })
@@ -116,7 +122,8 @@ class TestAGNewKitHandler(TestHandlerBase):
         # no kits given
         response = self.post('/ag_new_kit/',
                              {'tag': tag,
-                              'projects': ['PROJECT2', 'PROJECT5'],
+                              'projects': list(map(url_escape,
+                                                   ['PROJECT2', 'PROJECT5'])),
                               'swabs': swabs,
                               'kits': [],
                               })
@@ -127,7 +134,8 @@ class TestAGNewKitHandler(TestHandlerBase):
         # what if tag is None
         response = self.post('/ag_new_kit/',
                              {'tag': '',
-                              'projects': ['PROJECT2', 'PROJECT5'],
+                              'projects': list(map(url_escape,
+                                                   ['PROJECT2', 'PROJECT5'])),
                               'swabs': swabs,
                               'kits': kits,
                               })


### PR DESCRIPTION
Right now the DB only contains project names composed of plain ascii chars. That will change with the new DB dump, since project names are then subject to scrubbing, i.e. random utf8 chars will be in the names.
Thus, I updated handler and tests to properly escape those names when send and received as URL arguments.