### PR TITLE
Fixing knimin/tests/test_ag_update_geocode.py

### DIFF
--- a/knimin/lib/data_access.py
+++ b/knimin/lib/data_access.py
@@ -1978,7 +1978,9 @@ class KniminAccess(object):
                 break
 
             # Attempt to geocode
-            address = '{0} {1} {2} {3}'.format(city, state, zipcode, country)
+            address = '%s %s %s %s' % (
+                city.decode('utf-8'), state.decode('utf-8'),
+                zipcode.decode('utf-8'), country.decode('utf-8'))
             try:
                 info = geocode(address)
                 # empty string to indicate geocode was successful

--- a/knimin/tests/test_ag_update_geocode.py
+++ b/knimin/tests/test_ag_update_geocode.py
@@ -25,7 +25,7 @@ class TestAGUpdateGeocodeHandler(TestHandlerBase):
     def test_post(self):
         self.mock_login_admin()
         response = self.post('/ag_update_geocode/', {'retry': '0',
-                                                     'limit': '-1'})
+                                                     'limit': '10'})
         self.assertEqual(response.code, 200)
         for stat in db.getGeocodeStats():
             self.assertIn("<td>%s</td><td>%s</td>" % stat, response.body)


### PR DESCRIPTION
I had to add a limit on the test cause otherwise it will try to geocode the entire DB, which will take a while.

@sjanssen2 @antgonza quick review?