### PR TITLE
Pulldown temp view

### DIFF
--- a/knimin/lib/data_access.py
+++ b/knimin/lib/data_access.py
@@ -504,7 +504,10 @@ class KniminAccess(object):
                 SELECT ag_kit_barcode_id,
                        ag_kit_id,
                        barcode,
-                       multiple_ids.survey_id,
+                       CASE WHEN multiple_ids.survey_id IS NOT NULL
+                            THEN multiple_ids.survey_id
+                            ELSE ag.ag_kit_barcodes.survey_id
+                       END,
                        sample_barcode_file,
                        sample_barcode_file_md5,
                        site_sampled,
@@ -523,7 +526,7 @@ class KniminAccess(object):
                        deposited
                 FROM participant_barcodes
                 JOIN multiple_ids USING (ag_login_id, participant_name)
-                JOIN ag.ag_kit_barcodes USING (barcode)"""
+                FULL JOIN ag.ag_kit_barcodes USING (barcode)"""
 
         if self.warned_once is False:
             sys.stderr.write("WARNING: This is an extremely ugly hack. We need"

--- a/knimin/lib/data_access.py
+++ b/knimin/lib/data_access.py
@@ -529,8 +529,8 @@ class KniminAccess(object):
 
         if self.warned_once is False:
             sys.stderr.write("WARNING: This is an extremely ugly hack. We need"
-                             " to replace find a more apropriate solution soon"
-                             ". (Stefan Janssen 4/2/2017, see issue #184)\n")
+                             " to find a more apropriate solution soon. "
+                             "(Stefan Janssen 4/2/2017, see issue #184)\n")
             self.warned_once = True
 
         return s1 + ";\n" + s2 + ";\n" + s3 + ";\n" + \

--- a/knimin/lib/data_access.py
+++ b/knimin/lib/data_access.py
@@ -496,7 +496,7 @@ class KniminAccess(object):
         s2 = """CREATE OR REPLACE TEMP VIEW participant_barcodes AS
                 SELECT ag_login_id, participant_name, barcode
                 FROM multiple_ids mi
-                LEFT JOIN ag.ag_kit_barcodes USING(survey_id)"""
+                JOIN ag.ag_kit_barcodes USING(survey_id)"""
 
         # produce the cartesian product of barcodes and survey ids into a temp
         # view that is in a common column structure to ag_kit_barcodes
@@ -504,7 +504,7 @@ class KniminAccess(object):
                 SELECT ag_kit_barcode_id,
                        ag_kit_id,
                        barcode,
-                       survey_id,
+                       multiple_ids.survey_id,
                        sample_barcode_file,
                        sample_barcode_file_md5,
                        site_sampled,
@@ -521,11 +521,9 @@ class KniminAccess(object):
                        withdrawn,
                        refunded,
                        deposited
-                FROM ag.ag_kit_barcodes akb
-                LEFT JOIN participant_barcodes pb USING(barcode)
-                LEFT JOIN multiple_ids mi USING (ag_login_id,
-                                                 participant_name,
-                                                 survey_id)"""
+                FROM participant_barcodes
+                JOIN multiple_ids USING (ag_login_id, participant_name)
+                JOIN ag.ag_kit_barcodes USING (barcode)"""
 
         if self.warned_once is False:
             sys.stderr.write("WARNING: This is an extremely ugly hack. We need"

--- a/knimin/lib/tests/test_data_access.py
+++ b/knimin/lib/tests/test_data_access.py
@@ -348,6 +348,7 @@ class TestDataAccess(TestCase):
         # barcodes as participant_barcodes (values relative to the test
         # database)
         sql = """SELECT COUNT(DISTINCT(barcode)) FROM participant_barcodes"""
+        sql = db._fix_sql_statements(sql)
         obs = db._con.execute_fetchone(sql)
         exp = [871]
         self.assertEqual(obs, exp)
@@ -357,6 +358,7 @@ class TestDataAccess(TestCase):
         self.assertIn('FROM like_ag_kit_barcodes', sql)
         self.assertNotIn('(barcode)) FROM ag.ag_kit_barcodes', sql)
         obs = db._con.execute_fetchone(sql)
+        exp = [28865]
         self.assertEqual(obs, exp)
 
         # however, the resulting table does not have the same number of
@@ -366,7 +368,7 @@ class TestDataAccess(TestCase):
         self.assertIn('FROM like_ag_kit_barcodes', sql)
         self.assertNotIn('(survey_id)) FROM ag.ag_kit_barcodes', sql)
         obs = db._con.execute_fetchone(sql)
-        exp = [599]
+        exp = [11838]
         self.assertEqual(obs, exp)
 
         sql = """SELECT COUNT(DISTINCT(survey_id)) FROM multiple_ids"""
@@ -389,6 +391,7 @@ class TestDataAccess(TestCase):
         obs = db._con.execute_fetchone(sql)
         exp = None
         self.assertEqual(obs, exp)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
I know this is a very ugly, duct tape solution, but we need to be able to pull down information NOW.
The problem is that the table ag.ag_kit_barcode does not allow to have multiple survey_ids for one barcode. Thus, when the user assigns a barcode to a source, it is actually assigned to the latest survey_id the user created and overwrites already existing survey_id(s). 
In the long run, we need to correct this erroneous behaviour, but due to upcoming deadlines, this PR should enable us to deliver to the collaborator.

Please review with these special circumstances in mind!

~My question: is it worth to remove the temp view after the actual SQL statement is executed? Or can we relay on the fact that it is updated every execution time?~ Stupid me, it's a temp view